### PR TITLE
Use pelican default summary feature

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -13,7 +13,7 @@
 					<h1 class="entry-title">{{ article.title }}</h1>
 				</header><!-- .entry-header -->
 				<div class="entry-content">
-					{{ article.content|striptags|truncate(300,false,' ...') }}
+					{{ article.summary }}
 	        	</div><!-- .entry-content -->
 			</div>
 		</div>


### PR DESCRIPTION
# Description

If the default summary attribute is used, the default variables like `SUMMARY_MAX_LENGTH` could be well supported.

I am not sure the context to use the customized summary format instead of the pelican default summary. Please feel free to ignore this pull request if there is any project-specific concern.


# Verify this Pull Request
The update is applied to [this site](https://tai271828.github.io/). This is a screenshot taken before applying the code change:
![Selection_072](https://user-images.githubusercontent.com/3217432/104132220-13501e80-537c-11eb-9a47-b94e7d14f63a.png)

and this screenshot is taken after applying the code change.
![image](https://user-images.githubusercontent.com/3217432/104132185-ee5bab80-537b-11eb-9714-5d566322d500.png)
